### PR TITLE
Add Test Script

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
 	"description": "Metric / Imperial Unit Converter",
 	"main": "server.js",
 	"scripts": {
-		"start": "node server.js"
+		"start": "node server.js",
+		"test": "mocha ./tests/ --ui tdd"
 	},
 	"dependencies": {
 		"body-parser": "^1.19.0",


### PR DESCRIPTION
This is related to a forum post I made on Discourse:  
https://forum.freecodecamp.org/t/no-test-script-configured-for-boilerplate/448701

> To run the tests in the console, use the command `npm run test` . To open the Repl.it console, press Ctrl+Shift+P (Cmd if on a Mac) and type "open shell"

The instructions for this project suggests that we can run `npm run test` to be able to test the project, but `test` isn't defined in `package.json`.

This adds a one so that users can run tests themselves in the future.