### PR TITLE
fix: listening on port undefined

### DIFF
--- a/server.js
+++ b/server.js
@@ -38,9 +38,11 @@ app.use(function(req, res, next) {
     .send('Not Found');
 });
 
+const port = process.env.PORT || 3000;
+
 //Start our server and tests!
-app.listen(process.env.PORT || 3000, function () {
-  console.log("Listening on port " + process.env.PORT);
+app.listen(port, function () {
+  console.log("Listening on port " + port);
   if(process.env.NODE_ENV==='test') {
     console.log('Running Tests...');
     setTimeout(function () {


### PR DESCRIPTION
If PORT is not defined in .env, console.log("Listening on port " + process.env.PORT) will display "Listening on port undefined".
